### PR TITLE
Upgrade core.match 0.2.2 → 1.0.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "Clojure finite state machines"
   :dependencies [[org.clojure/clojure "1.7.0"]
 		 [dorothy "0.0.6"]
-                 [org.clojure/core.match "0.2.2"]]
+                 [org.clojure/core.match "1.0.0"]]
   :dev-dependencies [[server-socket "1.0.0"] ;; used for examples/simple_server.clj		     
 		     [org.clojars.weavejester/autodoc "0.9.0"]]
   :autodoc {:web-src-dir "https://github.com/cdorrat/reduce-fsm/"


### PR DESCRIPTION
Mirrors: https://github.com/cdorrat/reduce-fsm/pull/13